### PR TITLE
perf: compile regexes once using LazyLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lokomotiv"
 version = "20260127.0.2"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.80"
 description = "Local orchestration layer for coordinating multiple LLM backends"
 authors = ["ducks"]
 license = "MIT"

--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -168,13 +168,12 @@ impl ClaudeBackend {
             .await
             .context("Failed to execute claude command")?;
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-
         if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!("Claude CLI failed: {}", stderr);
         }
 
+        let stdout = String::from_utf8_lossy(&output.stdout);
         Ok(stdout.trim().to_string())
     }
 

--- a/src/backend/codex.rs
+++ b/src/backend/codex.rs
@@ -73,13 +73,12 @@ impl super::Backend for CodexBackend {
             .await
             .context("Failed to execute codex command")?;
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-
         if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!("Codex failed: {}", stderr);
         }
 
+        let stdout = String::from_utf8_lossy(&output.stdout);
         Ok(self.parse_output(&stdout))
     }
 


### PR DESCRIPTION
## Summary

Fixes issues from lok hunt self-dogfooding:
- #19: Regex compiled on every `interpolate()` call
- #21: Unused stderr allocation in claude.rs
- #22: Unused stderr allocation in codex.rs

## Changes

- Move regex compilation to `static LazyLock` in workflow.rs and fix.rs
- Only allocate stderr string when command fails in backend impls
- Bump MSRV to 1.80 (required for `std::sync::LazyLock`)

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy` clean (no MSRV warnings after bump)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)