### PR TITLE
fix(spawn): derive Clone instead of manual impl

### DIFF
--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -28,6 +28,7 @@ pub struct BackendProfile {
 }
 
 /// Smart delegation based on task type
+#[derive(Clone)]
 pub struct Delegator {
     profiles: HashMap<String, BackendProfile>,
 }

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -377,9 +377,3 @@ AGENT: frontend | Build the UI"#,
         Ok(summary)
     }
 }
-
-impl Clone for Delegator {
-    fn clone(&self) -> Self {
-        Delegator::new()
-    }
-}


### PR DESCRIPTION
## Summary

Replace buggy manual `Clone` impl for `Delegator` with `#[derive(Clone)]`.

Fixes #25

## Changes

- Add `#[derive(Clone)]` to `Delegator` struct in `src/delegation.rs`
- Remove manual `Clone` impl from `src/spawn.rs` (it was buggy anyway - called `new()` instead of cloning)

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy` clean

---

🤖 This fix was generated and applied automatically by lok's agentic workflow system.