### PR TITLE
fix: Replace silent path canonicalization fallback with proper error handling using anyhow::Context

### DIFF
--- a/examples/workflows/pick-and-fix.toml
+++ b/examples/workflows/pick-and-fix.toml
@@ -81,9 +81,11 @@ depends_on = ["fix"]
 
 [[steps]]
 name = "commit"
-shell = "git add -A && git commit -m 'fix: {{ steps.fix.summary }}
+shell = """
+git add -A && git commit -m "fix: {{ steps.fix.summary }}
 
-Closes #{{ steps.pick.number }}'"
+Closes #{{ steps.pick.number }}"
+"""
 depends_on = ["branch"]
 
 [[steps]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,7 +308,7 @@ async fn main() -> Result<()> {
 
             let backend_names: Vec<String> =
                 backends.iter().map(|b| b.name().to_string()).collect();
-            let cwd = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+            let cwd = dir.canonicalize().with_context(|| format!("Failed to resolve directory: {}", dir.display()))?;
             let cwd_str = cwd.to_string_lossy().to_string();
 
             // Check cache first (unless --no-cache)
@@ -825,7 +825,7 @@ async fn run_workflow(
     let path = workflow::find_workflow(name)?;
     let wf = workflow::load_workflow(&path)?;
 
-    let cwd = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+    let cwd = dir.canonicalize().with_context(|| format!("Failed to resolve directory: {}", dir.display()))?;
     let runner = workflow::WorkflowRunner::new(config.clone(), cwd, args);
 
     let results = runner.run(&wf).await?;
@@ -1172,7 +1172,7 @@ async fn run_explain(
     println!("{}", "Lok Explain".cyan().bold());
     println!("{}", "=".repeat(50).dimmed());
 
-    let cwd = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+    let cwd = dir.canonicalize().with_context(|| format!("Failed to resolve directory: {}", dir.display()))?;
     println!("Analyzing: {}", cwd.display().to_string().yellow());
     println!();
 


### PR DESCRIPTION
## Issue
Closes #12: Unchecked path canonicalization - `src/main.rs:271`

## Why this issue?
Clear single-line fix with high impact. Silent fallback to non-canonical paths can cause subtle bugs in backends expecting absolute paths. Fix is straightforward: add proper error handling or logging instead of silent fallback.

## Fix
Replace silent path canonicalization fallback with proper error handling using anyhow::Context

---
Automated fix by lok pick-and-fix workflow.