### PR TITLE
fix: Replace silent path canonicalization fallbacks with explicit error handling using anyhow Context

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -117,7 +117,9 @@ pub async fn run_query_with_config(
     cwd: &Path,
     config: &Config,
 ) -> Result<Vec<QueryResult>> {
-    let cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    let cwd = cwd
+        .canonicalize()
+        .with_context(|| format!("Directory not found: {}", cwd.display()))?;
     let default_timeout = config.defaults.timeout;
     let parallel = config.defaults.parallel;
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -198,7 +198,9 @@ Always explain your reasoning briefly before making tool calls."#,
     }
 
     pub async fn conduct(&self, task: &str, cwd: &Path) -> Result<String> {
-        let cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+        let cwd = cwd
+            .canonicalize()
+            .with_context(|| format!("Directory not found: {}", cwd.display()))?;
 
         println!("{}", "Conductor starting...".cyan().bold());
         println!("Task: {}", task);

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,7 +308,9 @@ async fn main() -> Result<()> {
 
             let backend_names: Vec<String> =
                 backends.iter().map(|b| b.name().to_string()).collect();
-            let cwd = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+            let cwd = dir
+                .canonicalize()
+                .with_context(|| format!("Directory not found: {}", dir.display()))?;
             let cwd_str = cwd.to_string_lossy().to_string();
 
             // Check cache first (unless --no-cache)
@@ -825,7 +827,9 @@ async fn run_workflow(
     let path = workflow::find_workflow(name)?;
     let wf = workflow::load_workflow(&path)?;
 
-    let cwd = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+    let cwd = dir
+        .canonicalize()
+        .with_context(|| format!("Directory not found: {}", dir.display()))?;
     let runner = workflow::WorkflowRunner::new(config.clone(), cwd, args);
 
     let results = runner.run(&wf).await?;
@@ -1172,7 +1176,9 @@ async fn run_explain(
     println!("{}", "Lok Explain".cyan().bold());
     println!("{}", "=".repeat(50).dimmed());
 
-    let cwd = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+    let cwd = dir
+        .canonicalize()
+        .with_context(|| format!("Directory not found: {}", dir.display()))?;
     println!("Analyzing: {}", cwd.display().to_string().yellow());
     println!();
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -36,7 +36,9 @@ impl Spawn {
     pub fn new(config: &Config, cwd: &Path) -> Result<Self> {
         Ok(Self {
             config: config.clone(),
-            cwd: cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf()),
+            cwd: cwd
+                .canonicalize()
+                .with_context(|| format!("Directory not found: {}", cwd.display()))?,
             delegator: Delegator::new(),
         })
     }


### PR DESCRIPTION
## Issue
Closes #12: Unchecked path canonicalization - `src/main.rs:271`

## Why this issue?
Clear, localized fix - replace silent fallback with proper error handling or logging. Single line change with high impact on debugging UX when paths fail to canonicalize.

## Fix
Replace silent path canonicalization fallbacks with explicit error handling using anyhow Context

---
Automated fix by lok pick-and-fix workflow.