### PR TITLE
fix: Replace unsafe .unwrap() with .ok_or_else() returning descriptive anyhow error

### DIFF
--- a/src/team.rs
+++ b/src/team.rs
@@ -65,12 +65,17 @@ impl Team {
         );
         println!();
 
-        // Find the primary backend (guaranteed to exist now)
+        // Find the primary backend (guaranteed to exist by validation above)
         let primary_backend = self
             .backends
             .iter()
             .find(|b| b.name() == primary.name)
-            .unwrap();
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Internal error: backend '{}' passed validation but not found in backend list",
+                    primary.name
+                )
+            })?;
 
         // Query primary
         println!("{} Querying {}...", "→".cyan(), primary.name.to_uppercase());


### PR DESCRIPTION
## Issue
Closes #14: Unsafe unwrap in team mode - `src/team.rs:73`

## Why this issue?
Simple focused fix - replace a single .unwrap() with proper Result handling. Clear scope, single location, prevents potential panics in production. High impact-to-effort ratio with minimal refactoring needed.

## Fix
Replace unsafe .unwrap() with .ok_or_else() returning descriptive anyhow error

This fix was developed through Claude + Codex consensus.

---
Automated fix by lok pick-and-fix workflow.