### PR TITLE
fix: Remove unnecessary title.clone() - move owned String directly into tuple

### DIFF
--- a/src/tasks/hunt.rs
+++ b/src/tasks/hunt.rs
@@ -371,7 +371,7 @@ fn parse_findings(results: &[QueryResult]) -> Vec<Finding> {
                         .trim()
                         .to_string();
 
-                    current_finding = Some((title.clone(), vec![rest.to_string()]));
+                    current_finding = Some((title, vec![rest.to_string()]));
                 }
             } else if let Some((_, ref mut body)) = current_finding {
                 // Add to current finding body


### PR DESCRIPTION
## Issue
Closes #13: Unnecessary string allocations in finding parser loop - `src/tasks/hunt.rs:374`

## Why this issue?
Clear scope (single location), simple optimization fix (avoid clone/to_string in loop), no refactoring needed, measurable performance impact for large hunt outputs

## Fix
Remove unnecessary title.clone() - move owned String directly into tuple

This fix was developed through Claude + Codex consensus.

---
Automated fix by lok pick-and-fix workflow.