### PR TITLE
fix: Fix error handling regression by gracefully handling directory entry errors with warning instead of aborting

### DIFF
--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -843,7 +843,18 @@ fn load_workflows_from_dir(dir: &Path) -> Result<Vec<(PathBuf, Workflow)>> {
     let mut workflows = Vec::new();
 
     for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!(
+                    "{} Failed to read directory entry in {}: {}",
+                    "warning:".yellow(),
+                    dir.display(),
+                    e
+                );
+                continue;
+            }
+        };
         let path = entry.path();
 
         if path.extension().map(|e| e == "toml").unwrap_or(false) {


### PR DESCRIPTION
## Issue
Closes #83: Fix error handling regression in directory iteration

## Why this issue?
Clear bug with specific behavior change: while let Ok(Some(entry)) terminates on first error instead of skipping like .flatten() did. Single focused fix, high impact since it can silently truncate directory listings on permission errors.

## Fix
Fix error handling regression by gracefully handling directory entry errors with warning instead of aborting

This fix was developed through Claude + Codex consensus.

---
Automated fix by lok pick-and-fix workflow.