### PR TITLE
fix: Add canonicalize_or_warn helper to utils.rs and replace 6 silent fallbacks with warning-printing version

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,6 +16,8 @@ use colored::Colorize;
 use futures::future::join_all;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::path::{Path, PathBuf};
+
+use crate::utils;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -117,7 +119,7 @@ pub async fn run_query_with_config(
     cwd: &Path,
     config: &Config,
 ) -> Result<Vec<QueryResult>> {
-    let cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    let cwd = utils::canonicalize_or_warn(cwd);
     let default_timeout = config.defaults.timeout;
     let parallel = config.defaults.parallel;
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -6,6 +6,8 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+use crate::utils;
+
 pub struct Conductor {
     api_key: SecretString,
     model: String,
@@ -198,7 +200,7 @@ Always explain your reasoning briefly before making tool calls."#,
     }
 
     pub async fn conduct(&self, task: &str, cwd: &Path) -> Result<String> {
-        let cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+        let cwd = utils::canonicalize_or_warn(cwd);
 
         println!("{}", "Conductor starting...".cyan().bold());
         println!("Task: {}", task);

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,15 +318,7 @@ async fn main() -> Result<()> {
 
             let backend_names: Vec<String> =
                 backends.iter().map(|b| b.name().to_string()).collect();
-            let cwd = dir.canonicalize().unwrap_or_else(|e| {
-                eprintln!(
-                    "{} Failed to canonicalize path '{}': {}",
-                    "warning:".yellow(),
-                    dir.display(),
-                    e
-                );
-                dir.clone()
-            });
+            let cwd = utils::canonicalize_or_warn(&dir);
             let cwd_str = cwd.to_string_lossy().to_string();
 
             // Check cache first (unless --no-cache)
@@ -854,15 +846,7 @@ async fn run_workflow(
     let path = workflow::find_workflow(name)?;
     let wf = workflow::load_workflow(&path)?;
 
-    let cwd = dir.canonicalize().unwrap_or_else(|e| {
-        eprintln!(
-            "{} Failed to canonicalize path '{}': {}",
-            "warning:".yellow(),
-            dir.display(),
-            e
-        );
-        dir.to_path_buf()
-    });
+    let cwd = utils::canonicalize_or_warn(dir);
     let runner = workflow::WorkflowRunner::new(config.clone(), cwd, args);
 
     let results = runner.run(&wf).await?;
@@ -1222,15 +1206,7 @@ async fn run_explain(
     println!("{}", "Lok Explain".cyan().bold());
     println!("{}", "=".repeat(50).dimmed());
 
-    let cwd = dir.canonicalize().unwrap_or_else(|e| {
-        eprintln!(
-            "{} Failed to canonicalize path '{}': {}",
-            "warning:".yellow(),
-            dir.display(),
-            e
-        );
-        dir.to_path_buf()
-    });
+    let cwd = utils::canonicalize_or_warn(dir);
     println!("Analyzing: {}", cwd.display().to_string().yellow());
     println!();
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -6,6 +6,8 @@ use colored::Colorize;
 use futures::future::join_all;
 use secrecy::ExposeSecret;
 use std::path::Path;
+
+use crate::utils;
 use std::sync::Arc;
 
 /// An agent task to be executed
@@ -36,7 +38,7 @@ impl Spawn {
     pub fn new(config: &Config, cwd: &Path) -> Result<Self> {
         Ok(Self {
             config: config.clone(),
-            cwd: cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf()),
+            cwd: utils::canonicalize_or_warn(cwd),
             delegator: Delegator::new(),
         })
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,22 @@
 //! Shared utility functions
 
+use colored::Colorize;
+use std::path::{Path, PathBuf};
+
+/// Attempts to canonicalize a path, printing a warning and returning
+/// the original path if canonicalization fails.
+pub fn canonicalize_or_warn(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|e| {
+        eprintln!(
+            "{} Failed to canonicalize path '{}': {}",
+            "warning:".yellow(),
+            path.display(),
+            e
+        );
+        path.to_path_buf()
+    })
+}
+
 /// Truncate a string to a maximum number of characters, adding "..." if truncated
 pub fn truncate(s: &str, max_chars: usize) -> String {
     let char_count = s.chars().count();


### PR DESCRIPTION
## Issue
Closes #44: Fix remaining canonicalize silent fallbacks

## Why this issue?
Clear scope with 3 specific locations listed (conductor.rs:201, backend/mod.rs:120, spawn.rs:39). Same fix pattern as already-merged PR for issue #20, so the solution is proven. High impact since silent fallbacks can mask real path errors. No open PR references this issue.

## Fix
Add canonicalize_or_warn helper to utils.rs and replace 6 silent fallbacks with warning-printing version

This fix was developed through Claude + Codex consensus.

---
Automated fix by lok pick-and-fix workflow.