### PR TITLE
fix: replace bare unwrap with expect on progress bar template

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -125,7 +125,7 @@ pub async fn run_query_with_config(
     pb.set_style(
         ProgressStyle::default_bar()
             .template("{spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} {msg}")
-            .unwrap()
+            .expect("hardcoded progress bar template should be valid")
             .progress_chars("#>-"),
     );
 


### PR DESCRIPTION
## Issue
Closes #8: Direct unwrap on progress bar template

## Consensus
Ran `lok run pick-and-propose` - Claude and Codex both agreed:
- The template is a hardcoded constant that should never fail
- `.expect()` with a message is the right pattern for this case
- No need for error propagation since this isn't a runtime error

## Change
```rust
// Before
.template("...").unwrap()

// After  
.template("...").expect("hardcoded progress bar template should be valid")
```

---
Fix proposed by lok, implemented by Claude Code.