### PR TITLE
Convert blocking file I/O to async with tokio::fs

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -117,7 +117,7 @@ pub async fn run_query_with_config(
     cwd: &Path,
     config: &Config,
 ) -> Result<Vec<QueryResult>> {
-    let cwd = crate::utils::canonicalize_or_warn(cwd);
+    let cwd = crate::utils::canonicalize_async(cwd).await;
     let default_timeout = config.defaults.timeout;
     let parallel = config.defaults.parallel;
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -198,7 +198,7 @@ Always explain your reasoning briefly before making tool calls."#,
     }
 
     pub async fn conduct(&self, task: &str, cwd: &Path) -> Result<String> {
-        let cwd = crate::utils::canonicalize_or_warn(cwd);
+        let cwd = crate::utils::canonicalize_async(cwd).await;
 
         println!("{}", "Conductor starting...".cyan().bold());
         println!("Task: {}", task);

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -33,10 +33,10 @@ pub struct Spawn {
 }
 
 impl Spawn {
-    pub fn new(config: &Config, cwd: &Path) -> Result<Self> {
+    pub async fn new(config: &Config, cwd: &Path) -> Result<Self> {
         Ok(Self {
             config: config.clone(),
-            cwd: crate::utils::canonicalize_or_warn(cwd),
+            cwd: crate::utils::canonicalize_async(cwd).await,
             delegator: Delegator::new(),
         })
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,8 +4,8 @@ use colored::Colorize;
 use std::path::{Path, PathBuf};
 
 /// Attempts to canonicalize a path, logging a warning and returning the original path on failure.
-pub fn canonicalize_or_warn(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|e| {
+pub async fn canonicalize_async(path: &Path) -> PathBuf {
+    tokio::fs::canonicalize(path).await.unwrap_or_else(|e| {
         eprintln!(
             "{} Failed to canonicalize path '{}': {}",
             "warning:".yellow(),


### PR DESCRIPTION
## Summary
- Replace all `std::fs` operations with `tokio::fs` equivalents
- Prevents blocking the async runtime during file operations
- Removes sync `canonicalize_or_warn`, adds async `canonicalize_async`

## Files Changed
| File | Change |
|------|--------|
| `utils.rs` | `canonicalize_or_warn` → `canonicalize_async` |
| `cache.rs` | `get()`/`set()` now async |
| `workflow.rs` | `find_workflow`, `load_workflow`, `list_workflows` async |
| `fix.rs` | `gather_code_context` async |
| `backend/mod.rs` | Uses `canonicalize_async` |
| `conductor.rs` | Uses `canonicalize_async` |
| `spawn.rs` | `Spawn::new()` async |
| `main.rs` | Call sites updated with `.await` |

## Test plan
- [x] `cargo build` - no warnings
- [x] `cargo test` - 102 tests pass
- [x] `cargo clippy` - no warnings

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)