### PR TITLE
fix: Replace fail-fast ? operator with graceful error handling that logs and continues on per-entry directory iteration errors

### DIFF
--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1557,7 +1557,20 @@ async fn load_workflows_from_dir(dir: &Path) -> Result<Vec<(PathBuf, Workflow)>>
     let mut workflows = Vec::new();
 
     let mut entries = tokio::fs::read_dir(dir).await?;
-    while let Some(entry) = entries.next_entry().await? {
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(e)) => e,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!(
+                    "{} Error reading directory entry in {}: {}",
+                    "warning:".yellow(),
+                    dir.display(),
+                    e
+                );
+                continue;
+            }
+        };
         let path = entry.path();
 
         if path.extension().map(|e| e == "toml").unwrap_or(false) {


### PR DESCRIPTION
## Issue
Closes #118: Behavioral change in load_workflows_from_dir error handling

## Why this issue?
Clear, focused bug fix with well-defined before/after behavior. The issue pinpoints the exact location (src/workflow.rs in load_workflows_from_dir) and the fix is straightforward: either restore the original silent-continue behavior or document the intentional fail-fast change. No major refactoring needed, just error handling adjustment.

## Fix
Replace fail-fast ? operator with graceful error handling that logs and continues on per-entry directory iteration errors

This fix was developed through Claude + Codex consensus.

---
Automated fix by lok pick-and-fix workflow.