### PR TITLE
fix: Clarify comment to accurately describe linear delay behavior for directory iteration

### DIFF
--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1596,7 +1596,7 @@ async fn load_workflows_from_dir(dir: &Path) -> Result<Vec<(PathBuf, Workflow)>>
                         e
                     );
                 }
-                // Backoff: 10ms * error_count to avoid hammering on transient failures
+                // Linear delay: 10ms * error_count to avoid hammering on transient filesystem issues
                 tokio::time::sleep(std::time::Duration::from_millis(
                     10 * consecutive_errors as u64,
                 ))


### PR DESCRIPTION
## Issue
Closes #127: Clarify or fix linear vs exponential backoff

## Why this issue?
Clear scope (rename comment or implement exponential), isolated to a single location (src/workflow.rs:1600-1602), no open PR, and fixes misleading terminology that could confuse future maintainers

## Fix
Clarify comment to accurately describe linear delay behavior for directory iteration

This fix was developed through Claude + Codex consensus.

---
Automated fix by lok pick-and-fix workflow.