### PR TITLE
fix: use Arc<str> and Arc<Path> to avoid cloning prompt/cwd per backend

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use colored::Colorize;
 use futures::future::join_all;
 use indicatif::{ProgressBar, ProgressStyle};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -118,6 +118,8 @@ pub async fn run_query_with_config(
     config: &Config,
 ) -> Result<Vec<QueryResult>> {
     let cwd = crate::utils::canonicalize_async(cwd).await;
+    let prompt: Arc<str> = Arc::from(prompt);
+    let cwd: Arc<Path> = Arc::from(cwd.as_path());
     let default_timeout = config.defaults.timeout;
     let parallel = config.defaults.parallel;
 
@@ -130,8 +132,8 @@ pub async fn run_query_with_config(
     );
 
     let query_one = |backend: Arc<dyn Backend>,
-                     prompt: String,
-                     cwd: PathBuf,
+                     prompt: Arc<str>,
+                     cwd: Arc<Path>,
                      pb: ProgressBar,
                      timeout: u64| async move {
         pb.set_message(format!("Querying {}...", backend.name()));
@@ -181,8 +183,8 @@ pub async fn run_query_with_config(
                 let timeout = get_timeout(backend.name());
                 query_one(
                     Arc::clone(backend),
-                    prompt.to_string(),
-                    cwd.clone(),
+                    Arc::clone(&prompt),
+                    Arc::clone(&cwd),
                     pb.clone(),
                     timeout,
                 )
@@ -195,8 +197,8 @@ pub async fn run_query_with_config(
             let timeout = get_timeout(backend.name());
             let result = query_one(
                 Arc::clone(backend),
-                prompt.to_string(),
-                cwd.clone(),
+                Arc::clone(&prompt),
+                Arc::clone(&cwd),
                 pb.clone(),
                 timeout,
             )


### PR DESCRIPTION
## Issue
Closes #7: Cloning prompt/cwd for every backend - `src/backend/mod.rs:184-185`

## Fix
Replace per-backend cloning with Arc sharing:
- `prompt: String` -> `Arc<str>`
- `cwd: PathBuf` -> `Arc<Path>`

This avoids allocating new String/PathBuf for each backend query. The prompt and cwd are now wrapped in Arc once at the start, and cloning the Arc is just a pointer copy + refcount increment.

## Notes
This was picked by lok pick-and-fix but failed verification due to leaving an unused `PathBuf` import. Fixed manually.

---
Automated fix by lok pick-and-fix workflow (with manual cleanup).