### PR TITLE
feat: add command_wrapper config for NixOS/Docker environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ Works without config. For customization, create `lok.toml` or
 [defaults]
 parallel = true
 timeout = 300
+# Wrap shell commands for isolated environments (NixOS, Docker)
+# command_wrapper = "nix-shell --run '{cmd}'"
+# command_wrapper = "docker exec dev sh -c '{cmd}'"
 
 [backends.codex]
 enabled = true
@@ -187,6 +190,25 @@ model = "qwen2.5-coder:7b"
 enabled = true
 ttl_hours = 24
 ```
+
+### Command Wrapper (NixOS/Docker)
+
+If you use isolated environments, shell commands in workflows may fail due to
+missing dependencies. Use `command_wrapper` to wrap all shell commands:
+
+```toml
+[defaults]
+# For NixOS with nix-shell
+command_wrapper = "nix-shell --run '{cmd}'"
+
+# For Docker
+command_wrapper = "docker exec dev sh -c '{cmd}'"
+
+# For direnv
+command_wrapper = "direnv exec . {cmd}"
+```
+
+The `{cmd}` placeholder is replaced with the actual command.
 
 ## Backend Strengths
 


### PR DESCRIPTION
## Summary
- Adds `command_wrapper` option to `[defaults]` in lok.toml
- Wraps all shell commands (verify, format, shell steps) with user-defined wrapper
- Enables NixOS and Docker users to run commands in their project's isolated environment

## Example
```toml
[defaults]
command_wrapper = "nix-shell --run '{cmd}'"
# or
command_wrapper = "docker exec dev sh -c '{cmd}'"
```

## Test plan
- [x] Added unit tests for config parsing
- [x] All existing tests pass
- [x] Clippy passes with no warnings
- [x] README updated with documentation

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)