### PR TITLE
fix: Wrap for_each iteration execution in retry loop with exponential backoff

### DIFF
--- a/.arf/records/20260207-062820/0001.arf
+++ b/.arf/records/20260207-062820/0001.arf
@@ -1,0 +1,6 @@
+what = "Start workflow: pick-and-fix"
+why = "Pick the best open issue and fix it with multi-backend consensus"
+
+[context]
+timestamp = "2026-02-07T06:28:20.492759786+00:00"
+workflow = "pick-and-fix"

--- a/.arf/records/20260207-062820/0002.arf
+++ b/.arf/records/20260207-062820/0002.arf
@@ -1,0 +1,8 @@
+what = "Start step: setup"
+why = "Query shell backend"
+
+[context]
+timestamp = "2026-02-07T06:28:20.499374813+00:00"
+workflow = "pick-and-fix"
+step = "setup"
+backend = "shell"

--- a/.arf/records/20260207-062820/0003.arf
+++ b/.arf/records/20260207-062820/0003.arf
@@ -1,0 +1,9 @@
+what = "Complete step: setup"
+why = "Step succeeded in 1234ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:28:21.733607813+00:00"
+workflow = "pick-and-fix"
+step = "setup"
+elapsed_ms = 1234

--- a/.arf/records/20260207-062820/0004.arf
+++ b/.arf/records/20260207-062820/0004.arf
@@ -1,0 +1,8 @@
+what = "Start step: list"
+why = "Query shell backend"
+
+[context]
+timestamp = "2026-02-07T06:28:21.734063144+00:00"
+workflow = "pick-and-fix"
+step = "list"
+backend = "shell"

--- a/.arf/records/20260207-062820/0005.arf
+++ b/.arf/records/20260207-062820/0005.arf
@@ -1,0 +1,8 @@
+what = "Start step: open_prs"
+why = "Query shell backend"
+
+[context]
+timestamp = "2026-02-07T06:28:21.734631956+00:00"
+workflow = "pick-and-fix"
+step = "open_prs"
+backend = "shell"

--- a/.arf/records/20260207-062820/0006.arf
+++ b/.arf/records/20260207-062820/0006.arf
@@ -1,0 +1,9 @@
+what = "Complete step: open_prs"
+why = "Step succeeded in 527ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:28:22.262368317+00:00"
+workflow = "pick-and-fix"
+step = "open_prs"
+elapsed_ms = 527

--- a/.arf/records/20260207-062820/0007.arf
+++ b/.arf/records/20260207-062820/0007.arf
@@ -1,0 +1,9 @@
+what = "Complete step: list"
+why = "Step succeeded in 537ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:28:22.271776993+00:00"
+workflow = "pick-and-fix"
+step = "list"
+elapsed_ms = 537

--- a/.arf/records/20260207-062820/0008.arf
+++ b/.arf/records/20260207-062820/0008.arf
@@ -1,0 +1,8 @@
+what = "Start step: pick"
+why = "Query claude backend"
+
+[context]
+timestamp = "2026-02-07T06:28:22.273490223+00:00"
+workflow = "pick-and-fix"
+step = "pick"
+backend = "claude"

--- a/.arf/records/20260207-062820/0009.arf
+++ b/.arf/records/20260207-062820/0009.arf
@@ -1,0 +1,13 @@
+what = "Query backend: claude"
+why = "Step 'pick' requires LLM analysis"
+how = '''
+Prompt: Here are the open issues for this repo:
+
+[{"body":"## Problem\n\nThe `fix` step in pick-and-fix freq...'''
+backup = "Retry with exponential backoff on transient failure"
+
+[context]
+timestamp = "2026-02-07T06:28:22.273622600+00:00"
+workflow = "pick-and-fix"
+step = "pick"
+backend = "claude"

--- a/.arf/records/20260207-062820/0010.arf
+++ b/.arf/records/20260207-062820/0010.arf
@@ -1,0 +1,10 @@
+what = "Backend claude responded"
+why = "Received response in 8429ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:28:30.703534475+00:00"
+workflow = "pick-and-fix"
+step = "pick"
+backend = "claude"
+elapsed_ms = 8429

--- a/.arf/records/20260207-062820/0011.arf
+++ b/.arf/records/20260207-062820/0011.arf
@@ -1,0 +1,9 @@
+what = "Complete step: pick"
+why = "Step succeeded in 8430ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:28:30.703819507+00:00"
+workflow = "pick-and-fix"
+step = "pick"
+elapsed_ms = 8430

--- a/.arf/records/20260207-062820/0012.arf
+++ b/.arf/records/20260207-062820/0012.arf
@@ -1,0 +1,8 @@
+what = "Start step: fetch"
+why = "Query shell backend"
+
+[context]
+timestamp = "2026-02-07T06:28:30.704561764+00:00"
+workflow = "pick-and-fix"
+step = "fetch"
+backend = "shell"

--- a/.arf/records/20260207-062820/0013.arf
+++ b/.arf/records/20260207-062820/0013.arf
@@ -1,0 +1,9 @@
+what = "Complete step: fetch"
+why = "Step succeeded in 762ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:28:31.467102255+00:00"
+workflow = "pick-and-fix"
+step = "fetch"
+elapsed_ms = 762

--- a/.arf/records/20260207-062820/0014.arf
+++ b/.arf/records/20260207-062820/0014.arf
@@ -1,0 +1,8 @@
+what = "Start step: propose_claude"
+why = "Query claude backend"
+
+[context]
+timestamp = "2026-02-07T06:28:31.468144332+00:00"
+workflow = "pick-and-fix"
+step = "propose_claude"
+backend = "claude"

--- a/.arf/records/20260207-062820/0015.arf
+++ b/.arf/records/20260207-062820/0015.arf
@@ -1,0 +1,13 @@
+what = "Query backend: claude"
+why = "Step 'propose_claude' requires LLM analysis"
+how = """
+Prompt: Analyze and propose a fix for this issue:
+
+Issue #153: Bug: for_each iterations don't retry on timeo..."""
+backup = "Retry with exponential backoff on transient failure"
+
+[context]
+timestamp = "2026-02-07T06:28:31.468254918+00:00"
+workflow = "pick-and-fix"
+step = "propose_claude"
+backend = "claude"

--- a/.arf/records/20260207-062820/0016.arf
+++ b/.arf/records/20260207-062820/0016.arf
@@ -1,0 +1,8 @@
+what = "Start step: propose_codex"
+why = "Query codex backend"
+
+[context]
+timestamp = "2026-02-07T06:28:31.468500647+00:00"
+workflow = "pick-and-fix"
+step = "propose_codex"
+backend = "codex"

--- a/.arf/records/20260207-062820/0017.arf
+++ b/.arf/records/20260207-062820/0017.arf
@@ -1,0 +1,13 @@
+what = "Query backend: codex"
+why = "Step 'propose_codex' requires LLM analysis"
+how = """
+Prompt: Analyze and propose a fix for this issue:
+
+Issue #153: Bug: for_each iterations don't retry on timeo..."""
+backup = "Retry with exponential backoff on transient failure"
+
+[context]
+timestamp = "2026-02-07T06:28:31.468599722+00:00"
+workflow = "pick-and-fix"
+step = "propose_codex"
+backend = "codex"

--- a/.arf/records/20260207-062820/0018.arf
+++ b/.arf/records/20260207-062820/0018.arf
@@ -1,0 +1,8 @@
+what = "Start step: propose_gemini"
+why = "Query gemini backend"
+
+[context]
+timestamp = "2026-02-07T06:28:31.468916985+00:00"
+workflow = "pick-and-fix"
+step = "propose_gemini"
+backend = "gemini"

--- a/.arf/records/20260207-062820/0019.arf
+++ b/.arf/records/20260207-062820/0019.arf
@@ -1,0 +1,13 @@
+what = "Query backend: gemini"
+why = "Step 'propose_gemini' requires LLM analysis"
+how = """
+Prompt: Analyze and propose a fix for this issue:
+
+Issue #153: Bug: for_each iterations don't retry on timeo..."""
+backup = "Retry with exponential backoff on transient failure"
+
+[context]
+timestamp = "2026-02-07T06:28:31.469031459+00:00"
+workflow = "pick-and-fix"
+step = "propose_gemini"
+backend = "gemini"

--- a/.arf/records/20260207-062820/0020.arf
+++ b/.arf/records/20260207-062820/0020.arf
@@ -1,0 +1,10 @@
+what = "Backend codex responded"
+why = "Received response in 17404ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:28:48.873207451+00:00"
+workflow = "pick-and-fix"
+step = "propose_codex"
+backend = "codex"
+elapsed_ms = 17404

--- a/.arf/records/20260207-062820/0021.arf
+++ b/.arf/records/20260207-062820/0021.arf
@@ -1,0 +1,9 @@
+what = "Complete step: propose_codex"
+why = "Step succeeded in 17404ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:28:48.873432331+00:00"
+workflow = "pick-and-fix"
+step = "propose_codex"
+elapsed_ms = 17404

--- a/.arf/records/20260207-062820/0022.arf
+++ b/.arf/records/20260207-062820/0022.arf
@@ -1,0 +1,10 @@
+what = "Backend claude responded"
+why = "Received response in 23169ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:28:54.638058152+00:00"
+workflow = "pick-and-fix"
+step = "propose_claude"
+backend = "claude"
+elapsed_ms = 23169

--- a/.arf/records/20260207-062820/0023.arf
+++ b/.arf/records/20260207-062820/0023.arf
@@ -1,0 +1,9 @@
+what = "Complete step: propose_claude"
+why = "Step succeeded in 23170ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:28:54.638301817+00:00"
+workflow = "pick-and-fix"
+step = "propose_claude"
+elapsed_ms = 23170

--- a/.arf/records/20260207-062820/0024.arf
+++ b/.arf/records/20260207-062820/0024.arf
@@ -1,0 +1,10 @@
+what = "Backend gemini responded"
+why = "Received response in 41743ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:29:13.212650866+00:00"
+workflow = "pick-and-fix"
+step = "propose_gemini"
+backend = "gemini"
+elapsed_ms = 41743

--- a/.arf/records/20260207-062820/0025.arf
+++ b/.arf/records/20260207-062820/0025.arf
@@ -1,0 +1,9 @@
+what = "Complete step: propose_gemini"
+why = "Step succeeded in 41743ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:29:13.212838256+00:00"
+workflow = "pick-and-fix"
+step = "propose_gemini"
+elapsed_ms = 41743

--- a/.arf/records/20260207-062820/0026.arf
+++ b/.arf/records/20260207-062820/0026.arf
@@ -1,0 +1,8 @@
+what = "Start step: debate"
+why = "Query claude backend"
+
+[context]
+timestamp = "2026-02-07T06:29:13.213307422+00:00"
+workflow = "pick-and-fix"
+step = "debate"
+backend = "claude"

--- a/.arf/records/20260207-062820/0027.arf
+++ b/.arf/records/20260207-062820/0027.arf
@@ -1,0 +1,13 @@
+what = "Query backend: claude"
+why = "Step 'debate' requires LLM analysis"
+how = """
+Prompt: Three AI backends proposed fixes for Issue #153: Bug: for_each iterations don't retry on timeout
+
+CL..."""
+backup = "Retry with exponential backoff on transient failure"
+
+[context]
+timestamp = "2026-02-07T06:29:13.213419291+00:00"
+workflow = "pick-and-fix"
+step = "debate"
+backend = "claude"

--- a/.arf/records/20260207-062820/0028.arf
+++ b/.arf/records/20260207-062820/0028.arf
@@ -1,0 +1,10 @@
+what = "Backend claude responded"
+why = "Received response in 14647ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:29:27.860578920+00:00"
+workflow = "pick-and-fix"
+step = "debate"
+backend = "claude"
+elapsed_ms = 14647

--- a/.arf/records/20260207-062820/0029.arf
+++ b/.arf/records/20260207-062820/0029.arf
@@ -1,0 +1,9 @@
+what = "Complete step: debate"
+why = "Step succeeded in 14647ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:29:27.860880333+00:00"
+workflow = "pick-and-fix"
+step = "debate"
+elapsed_ms = 14647

--- a/.arf/records/20260207-062820/0030.arf
+++ b/.arf/records/20260207-062820/0030.arf
@@ -1,0 +1,8 @@
+what = "Start step: fix"
+why = "Query claude backend"
+
+[context]
+timestamp = "2026-02-07T06:29:27.861426914+00:00"
+workflow = "pick-and-fix"
+step = "fix"
+backend = "claude"

--- a/.arf/records/20260207-062820/0031.arf
+++ b/.arf/records/20260207-062820/0031.arf
@@ -1,0 +1,13 @@
+what = "Query backend: claude"
+why = "Step 'fix' requires LLM analysis"
+how = """
+Prompt: Implement the consensus fix for Issue #153: Bug: for_each iterations don't retry on timeout
+
+The deb..."""
+backup = "Retry with exponential backoff on transient failure"
+
+[context]
+timestamp = "2026-02-07T06:29:27.861537641+00:00"
+workflow = "pick-and-fix"
+step = "fix"
+backend = "claude"

--- a/.arf/records/20260207-062820/0032.arf
+++ b/.arf/records/20260207-062820/0032.arf
@@ -1,0 +1,10 @@
+what = "Backend claude responded"
+why = "Received response in 46956ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:30:14.817731164+00:00"
+workflow = "pick-and-fix"
+step = "fix"
+backend = "claude"
+elapsed_ms = 46956

--- a/.arf/records/20260207-062820/0033.arf
+++ b/.arf/records/20260207-062820/0033.arf
@@ -1,0 +1,10 @@
+what = "Apply edit to src/workflow.rs"
+why = "LLM proposed code change"
+backup = "Rollback via git if verification fails"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:30:14.819496351+00:00"
+workflow = "pick-and-fix"
+step = "fix"
+file = "src/workflow.rs"

--- a/.arf/records/20260207-062820/0034.arf
+++ b/.arf/records/20260207-062820/0034.arf
@@ -1,0 +1,8 @@
+what = "Verify: cargo fmt && cargo fix --allow-dirty --allow-staged 2>/dev/null; cargo clippy -- -D warnings && cargo build"
+why = "Validate applied changes"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:30:21.177482943+00:00"
+workflow = "pick-and-fix"
+step = "fix"

--- a/.arf/records/20260207-062820/0035.arf
+++ b/.arf/records/20260207-062820/0035.arf
@@ -1,0 +1,9 @@
+what = "Complete step: fix"
+why = "Step succeeded in 46956ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:30:21.177676023+00:00"
+workflow = "pick-and-fix"
+step = "fix"
+elapsed_ms = 46956

--- a/.arf/records/20260207-062820/0036.arf
+++ b/.arf/records/20260207-062820/0036.arf
@@ -1,0 +1,8 @@
+what = "Start step: branch"
+why = "Query shell backend"
+
+[context]
+timestamp = "2026-02-07T06:30:21.180662211+00:00"
+workflow = "pick-and-fix"
+step = "branch"
+backend = "shell"

--- a/.arf/records/20260207-062820/0037.arf
+++ b/.arf/records/20260207-062820/0037.arf
@@ -1,0 +1,9 @@
+what = "Complete step: branch"
+why = "Step succeeded in 7ms"
+outcome = "success"
+
+[context]
+timestamp = "2026-02-07T06:30:21.187745933+00:00"
+workflow = "pick-and-fix"
+step = "branch"
+elapsed_ms = 7

--- a/.arf/records/20260207-062820/0038.arf
+++ b/.arf/records/20260207-062820/0038.arf
@@ -1,0 +1,8 @@
+what = "Start step: commit"
+why = "Query shell backend"
+
+[context]
+timestamp = "2026-02-07T06:30:21.188442935+00:00"
+workflow = "pick-and-fix"
+step = "commit"
+backend = "shell"


### PR DESCRIPTION
## Issue
Closes #153: Bug: for_each iterations don't retry on timeout

## Why this issue?
Clear bug with defined scope - for_each loops don't retry on timeout while regular steps do. The fix location is identified (src/workflow.rs:527-591), the expected behavior is clear (match retry behavior of regular steps at lines 683-698, 795-808), and it's a focused code change to add retry logic to the for_each timeout handling path.

## Fix
Wrap for_each iteration execution in retry loop with exponential backoff

This fix was developed through Claude + Codex + Gemini consensus.

---
Automated fix by lok pick-and-fix workflow.