### PR TITLE
feat: Add fix_retries for workflow verification failures

### DIFF
--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1386,9 +1386,17 @@ impl WorkflowRunner {
                                                     "{}\n\n## Previous Attempt Failed\n\nVerification error:\n```\n{}\n```\n\nPlease provide a corrected fix.",
                                                     prompt, error_msg
                                                 );
-                                                if let Ok(new_response) = backend.query(&fix_prompt, &cwd).await {
-                                                    current_text = new_response;
-                                                    continue 'fix_loop;
+                                                match tokio::time::timeout(timeout_duration, backend.query(&fix_prompt, &cwd)).await {
+                                                    Ok(Ok(new_response)) => {
+                                                        current_text = new_response;
+                                                        continue 'fix_loop;
+                                                    }
+                                                    Ok(Err(e)) => {
+                                                        println!("    {} Re-query failed: {}", "✗".red(), e);
+                                                    }
+                                                    Err(_) => {
+                                                        println!("    {} Re-query timed out", "✗".red());
+                                                    }
                                                 }
                                             }
                                             // No retries left or re-query failed
@@ -1426,9 +1434,17 @@ impl WorkflowRunner {
                                                     "{}\n\n## Previous Attempt Failed\n\n{}\n\nPlease provide a corrected fix.",
                                                     prompt, error_msg
                                                 );
-                                                if let Ok(new_response) = backend.query(&fix_prompt, &cwd).await {
-                                                    current_text = new_response;
-                                                    continue 'fix_loop;
+                                                match tokio::time::timeout(timeout_duration, backend.query(&fix_prompt, &cwd)).await {
+                                                    Ok(Ok(new_response)) => {
+                                                        current_text = new_response;
+                                                        continue 'fix_loop;
+                                                    }
+                                                    Ok(Err(e)) => {
+                                                        println!("    {} Re-query failed: {}", "✗".red(), e);
+                                                    }
+                                                    Err(_) => {
+                                                        println!("    {} Re-query timed out", "✗".red());
+                                                    }
                                                 }
                                             }
                                             // No retries left or re-query failed
@@ -1452,6 +1468,8 @@ impl WorkflowRunner {
                             } // end 'fix_loop
 
                             // Record step complete (success)
+                            // Recalculate elapsed time to include any fix retries
+                            let elapsed_ms = start.elapsed().as_millis() as u64;
 
                             let parsed = parse_step_output(
                                 &current_text,


### PR DESCRIPTION
## Summary

When a step with `apply_edits` and `verify` fails verification, the workflow can now automatically retry by re-querying the LLM with the error message.

## Changes

- Add `fix_retries` field to Step struct
- Wrap apply/verify in `'fix_loop` that retries on failure
- Roll back via git-agent before retry
- Re-query backend with error context appended to prompt

## Usage

```toml
[[steps]]
name = "fix"
apply_edits = true
verify = "cargo clippy"
fix_retries = 2
```

When verification fails, the workflow will:
1. Roll back changes via git-agent
2. Re-query the LLM with: original prompt + error message
3. Apply new edits and verify again
4. Repeat up to `fix_retries` times

## Test plan

- [x] Compiles cleanly
- [x] Existing tests pass
- [x] Added to pick-and-fix workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)