### PR TITLE
fix: Replace None outcome with descriptive messages for zero/single participant debates

### DIFF
--- a/src/debate.rs
+++ b/src/debate.rs
@@ -76,7 +76,12 @@ impl<'a> Debate<'a> {
                 .first()
                 .map(|p| p.stance.clone())
                 .unwrap_or_default();
-            let markdown = self.build_markdown(&participants, &rounds, None);
+            let outcome = if positions.is_empty() {
+                Some("No participants responded")
+            } else {
+                Some("Single participant - no debate possible")
+            };
+            let markdown = self.build_markdown(&participants, &rounds, outcome);
             return Ok(DebateOutput { summary, markdown });
         }
 


### PR DESCRIPTION
## Issue
Closes #193: Handle outcome for single/zero participant debates

## Why this issue?
Clear bug with specific location (debate.rs:66), simple fix to pass a concrete outcome string instead of None, no dependencies on other issues, and improves UX consistency with minimal code change

## Fix
Replace None outcome with descriptive messages for zero/single participant debates

This fix was developed through Claude + Codex + Gemini consensus.

---
Automated fix by lok pick-and-fix workflow.